### PR TITLE
Feat: add print button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0",
         "react-scripts": "5.0.1",
+        "react-to-print": "^2.15.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -27,7 +28,7 @@
         "eslint-config-prettier": "^9.1.0",
         "husky": "^9.0.10",
         "prettier": "^3.2.4",
-        "typescript": "^5.3.3"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -14834,6 +14835,15 @@
         }
       }
     },
+    "node_modules/react-to-print": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-2.15.1.tgz",
+      "integrity": "sha512-1foogIFbCpzAVxydkhBiDfMiFYhIMphiagDOfcG4X/EcQ+fBPqJ0rby9Wv/emzY1YLkIQy/rEgOrWQT+rBKhjw==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -16808,15 +16818,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",
     "react-scripts": "5.0.1",
+    "react-to-print": "^2.15.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -49,6 +50,6 @@
     "eslint-config-prettier": "^9.1.0",
     "husky": "^9.0.10",
     "prettier": "^3.2.4",
-    "typescript": "^5.3.3"
+    "typescript": "^4.9.5"
   }
 }

--- a/src/apps/cross-math/App.css
+++ b/src/apps/cross-math/App.css
@@ -7,6 +7,7 @@
     'wght' 400,
     'GRAD' 0,
     'opsz' 24;
+  font-size: medium;
 }
 
 .content {
@@ -138,6 +139,17 @@
   box-sizing: border-box;
 }
 
+.puzzle-for-print {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  & .puzzle-container {
+    box-shadow: none;
+  }
+}
+
 .controller {
   display: flex;
   width: 100%;
@@ -156,6 +168,11 @@
   border: none;
   background: none;
   cursor: pointer;
+}
+
+.view-controller {
+  position: absolute;
+  right: 0;
 }
 
 .create {
@@ -194,11 +211,6 @@
 .undo,
 .redo {
   font-size: 1rem;
-}
-
-.show-ans {
-  position: absolute;
-  right: 0;
 }
 
 .puzzle {

--- a/src/apps/cross-math/App.tsx
+++ b/src/apps/cross-math/App.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Board, Puzzle, Operator, BoardRequirement } from './lib/Puzzle'
 import './App.css'
+import { useReactToPrint } from 'react-to-print'
 
 interface Option {
   row: number
@@ -48,6 +49,8 @@ export default function App() {
   const [isDomainSelectorActive, setIsDomainSelectorActive] = useState(false)
   const [tiles, setTiles] = useState<Tile[]>([])
   const [showAns, setShowAns] = useState(false)
+
+  const printRef = useRef(null)
 
   const changeRowCol = (row: boolean, inc: boolean) => {
     setOption(prev => {
@@ -211,6 +214,11 @@ export default function App() {
     })
   }
 
+  const printHandler = useReactToPrint({
+    content: () => printRef.current,
+    documentTitle: '가로세로 연산',
+  })
+
   const answerHandler = () => {
     setShowAns(prev => !prev)
   }
@@ -256,6 +264,41 @@ export default function App() {
     puzzle.fixedBoard = option.fixedBoard
     updateTile()
   }, [option])
+
+  const PuzzleContainer = () => {
+    return (
+      <div className="puzzle-container">
+        <div
+          className="puzzle"
+          style={{
+            gridTemplateColumns: `repeat(${option.col * 2 + 1}, minmax(0, 1fr))`,
+            gridTemplateRows: `repeat(${option.row * 2 + 1}, minmax(0, 1fr))`,
+          }}>
+          {tiles.map((t, idx) => (
+            <div
+              className={`tile ${t.type}`}
+              onClick={() => fixHandler(idx)}
+              key={idx}>
+              {t.fixed ? <div className="fixed-flag m-icon">push_pin</div> : ''}
+              <div className="label">
+                {t.type === 'operand' && !showAns ? '' : formatLabel(t)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const PuzzleForPrint = () => {
+    return (
+      <div
+        className="puzzle-for-print"
+        ref={printRef}>
+        <PuzzleContainer />
+      </div>
+    )
+  }
 
   return (
     <div className="content">
@@ -330,37 +373,24 @@ export default function App() {
                 redo
               </button>
             </div>
-            <button
-              className="show-ans button m-icon"
-              onClick={answerHandler}>
-              {showAns ? 'visibility' : 'visibility_off'}
-            </button>
-          </div>
-        </div>
-        <div className="puzzle-container">
-          <div
-            className="puzzle"
-            style={{
-              gridTemplateColumns: `repeat(${option.col * 2 + 1}, minmax(0, 1fr))`,
-              gridTemplateRows: `repeat(${option.row * 2 + 1}, minmax(0, 1fr))`,
-            }}>
-            {tiles.map((t, idx) => (
-              <div
-                className={`tile ${t.type}`}
-                onClick={() => fixHandler(idx)}
-                key={idx}>
-                {t.fixed ? (
-                  <div className="fixed-flag m-icon">push_pin</div>
-                ) : (
-                  ''
-                )}
-                <div className="label">
-                  {t.type === 'operand' && !showAns ? '' : formatLabel(t)}
+            <div className="view-controller">
+              <button
+                className="print button m-icon"
+                onClick={printHandler}>
+                print
+                <div style={{ display: 'none' }}>
+                  <PuzzleForPrint />
                 </div>
-              </div>
-            ))}
+              </button>
+              <button
+                className="show-ans button m-icon"
+                onClick={answerHandler}>
+                {showAns ? 'visibility' : 'visibility_off'}
+              </button>
+            </div>
           </div>
         </div>
+        <PuzzleContainer />
       </div>
     </div>
   )


### PR DESCRIPTION
### 프린트 버튼을 추가합니다. [Issue](https://github.com/woooil/s/issues/12#issue-2329572766)
- 'react-to-print'를 이용하여 만든 버튼을 누르면(좌), 퍼즐 부분만 프린트 할 수 있습니다(우).
<img width="350" alt="image" src="https://github.com/woooil/s/assets/79096116/cc9545e1-10fc-413f-b6b5-8fbfea42b03f">
<img width="350" alt="image" src="https://github.com/woooil/s/assets/79096116/a047074f-2f47-4614-acb3-f27ef307be09">
